### PR TITLE
init.sqlの要素をすべて小文字に修正

### DIFF
--- a/ChatApp/app.py
+++ b/ChatApp/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, flash, redirect, url_for
 import logging
 from flask import session
-from models import db_pool
+from models import db_pool, User
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -46,10 +46,20 @@ def signup_parent():
         password = request.form.get('password')
         password_confirmation = request.form.get('password_confirmation')
         user_type = request.form.get('user_type')
-        print(f"ログイン試行: ユーザー種別={user_type}, メールアドレス={email}, パスワード={password}")
         
         if not email or not password:
             flash('メールアドレスとパスワードを入力してください')
+            return render_template('auth/signup-parent.html', email=email, parent_user_name=parent_user_name)
+        
+        # ここでDBにユーザーを登録
+        try:
+            import uuid
+            uid = str(uuid.uuid4())
+            User.create(uid, parent_user_name, email, password)
+            flash('アカウント登録が完了しました。ログインしてください。')
+            return redirect(url_for('login'))
+        except Exception as e:
+            flash(f'登録に失敗しました: {e}')
             return render_template('auth/signup-parent.html', email=email, parent_user_name=parent_user_name)
         
     return render_template('auth/signup-parent.html', email=email, parent_user_name=parent_user_name)

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -14,8 +14,8 @@ class User:
        conn = db_pool.get_conn()
        try:
            with conn.cursor() as cur:
-               sql = "INSERT INTO users (uid, user_name, email, password) VALUES (%s, %s, %s, %s);"
-               cur.execute(sql, (uid, name, email, password,))
+               sql = "INSERT INTO parents (parent_user_name, email, password) VALUES (%s, %s, %s);"
+               cur.execute(sql, (name, email, password,))
                conn.commit()
        except pymysql.Error as e:
            print(f'エラーが発生しています：{e}')
@@ -29,7 +29,7 @@ class User:
        conn = db_pool.get_conn()
        try:
                with conn.cursor() as cur:
-                   sql = "SELECT * FROM users WHERE email=%s;"
+                   sql = "SELECT * FROM parents WHERE email=%s;"
                    cur.execute(sql, (email,))
                    user = cur.fetchone()
                return user

--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -1,4 +1,3 @@
--- 既存のデータベースの削除　テスト環境の場合やり直すことがあるため、クリーンな状態から始められるようにする。
 DROP DATABASE IF EXISTS chatapp;
 DROP USER IF EXISTS 'testuser'@'%';
 
@@ -7,102 +6,65 @@ CREATE USER IF NOT EXISTS 'testuser'@'%' IDENTIFIED BY 'testuser';
 GRANT ALL PRIVILEGES ON chatapp.* TO 'testuser'@'%';
 FLUSH PRIVILEGES;
 
--- Parentsテーブルの作成
-CREATE TABLE Parents (
---parent_idをint型　AUTO_INCREMENTで連番　主キー
-parent_id INT AUTO_INCREMENT PRIMARY KEY,
--- parent_user_name VARCHAR(255)　ユニークキーとして設定し他のユーザーと被らないように　NOT NULLでNULLができないように
-parent_user_name VARCHAR(255) UNIQUE NOT NULL,
--- email VARCHAR(255)　ユニークキーとして設定し他のユーザーと被らないように　NOT NULLでNULLができないように
-email VARCHAR(255) UNIQUE NOT NULL,
---password VARCHAR(255)　
-password VARCHAR(255) NOT NULL,
--- 作成日
-create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
--- update_at ON UPDATEで新しく取得した現在の日時を返す
-updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+-- parentsテーブルの作成
+CREATE TABLE parents (
+  parent_id INT AUTO_INCREMENT PRIMARY KEY,
+  parent_user_name VARCHAR(255) UNIQUE NOT NULL,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- childrenテーブルの作成
-CREATE TABLE Children (
--- child_id INT型　AUTO_INCREMENTで連番　主キー
-child_id INT AUTO_INCREMENT PRIMARY KEY,
--- child_user_name VARCHAR型 UNIQUEに設定　NOT NULL
-child_user_name VARCHAR(255) UNIQUE NOT NULL,
--- child_email VARCHAR型　UNIQUEに設定 NOT NULL
-child_email VARCHAR(255) UNIQUE NOT NULL,
--- password VARCHAR型　NOT NULL
-password VARCHAR(255) NOT NULL,
--- friend_child_user_id VARCHAR型　UNIQUEに設定　NOT NULL
-friend_child_user_id VARCHAR(255) UNIQUE NOT NULL,
--- 作成日
-create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
--- update_at ON UPDATEで新しく取得した現在の日時を返す
-updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
--- parent_id INT型　NOT NULL 外部キー
-parent_id INT NOT NULL,
--- child_status 0と1で使用可能と禁止のステータス変更　CHECKで0と1以外の値が入らないようにする。DEFAULT句で最初の値を0とする。
-child_status INT DEFAULT 0 CHECK(child_status IN (0, 1)),
--- 外部キー ON DELETE CASCADEつける必要あり？親ユーザーが削除された場合に子ユーザーも削除されてしまう？
-FOREIGN KEY(parent_id) REFERENCES parent_users(parent_id) ON DELETE CASCADE
+CREATE TABLE children (
+  child_id INT AUTO_INCREMENT PRIMARY KEY,
+  child_user_name VARCHAR(255) UNIQUE NOT NULL,
+  child_email VARCHAR(255) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  friend_child_user_id VARCHAR(255) UNIQUE NOT NULL,
+  create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  parent_id INT NOT NULL,
+  child_status INT DEFAULT 0 CHECK(child_status IN (0, 1)),
+  FOREIGN KEY(parent_id) REFERENCES parents(parent_id) ON DELETE CASCADE
 );
 
-CREATE TABLE Friends (
--- unique_id INT型　主キー
-friend_id INT AUTO_INCREMENT PRIMARY KEY,
--- child_id INT型 NOT NULL 外部キー
-child_id INT NOT NULL,
--- user_id　VARCHAR型 NOT NULL 外部キー
-friend_child_user_id VARCHAR(255) NOT NULL,
-FOREIGN KEY (child_id) REFERENCES Children(child_id) ON DELETE CASCADE,
-FOREIGN KEY (friend_child_user_id) REFERENCES Children(friend_child_user_id) ON DELETE CASCADE
+CREATE TABLE friends (
+  friend_id INT AUTO_INCREMENT PRIMARY KEY,
+  child_id INT NOT NULL,
+  friend_child_user_id VARCHAR(255) NOT NULL,
+  FOREIGN KEY (child_id) REFERENCES children(child_id) ON DELETE CASCADE,
+  FOREIGN KEY (friend_child_user_id) REFERENCES children(friend_child_user_id) ON DELETE CASCADE
 );
 
-CREATE Channels(
--- channel_id INT型　主キー
-channel_id INT AUTO_INCREMENT PRIMARY KEY,
--- channel_name VARCHAR型　NOT NULL
-channel_name VARCHAR(255) NOT NULL,
--- created_by INT型 NOT NULL 外部キー
-created_by INT NOT NULL,
--- create_at TIMESTAMP型
-created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
--- update_at ON UPDATEで新しく取得した現在の日時を返す
-updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-FOREIGN KEY(created_by) REFERENCES Child_users(child_id) ON DELETE CASCADE,  
+CREATE TABLE channels (
+  channel_id INT AUTO_INCREMENT PRIMARY KEY,
+  channel_name VARCHAR(255) NOT NULL,
+  created_by INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY(created_by) REFERENCES children(child_id) ON DELETE CASCADE
 );
 
-CREATE Member_tables(
--- child_id INT型 NOT NULL 外部キー DELETE CASCADE必要？
-child_id INT NOT NULL,
--- channel_id INT型 NOT NULL 外部キー
-channel_id INT NOT NULL,
--- unique_id INT型　主キー
-unique_id INT AUTO_INCREMENT PRIMARY KEY,
--- create_at TIMESTAMP型　
-create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
--- update_at ON UPDATEで新しく取得した現在の日時を返す
-updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-FOREIGN KEY (child_id) REFERENCES Child_users(child_id) ON DELETE CASCADE,
-FOREIGN KEY(channel_id) REFERENCES Channel_tables(channel_id) ON DELETE CASCADE,
+CREATE TABLE member_tables (
+  child_id INT NOT NULL,
+  channel_id INT NOT NULL,
+  unique_id INT AUTO_INCREMENT PRIMARY KEY,
+  create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (child_id) REFERENCES children(child_id) ON DELETE CASCADE,
+  FOREIGN KEY(channel_id) REFERENCES channels(channel_id) ON DELETE CASCADE
 );
 
-CREATE Messages(
-message_id INT AUTO_INCREMENT PRIMARY KEY,
-child_id INT NOT NULL,
-message_content text NOT NULL,
-send_date TIMESTAMP,
-channel_id INT NOT NULL,
-create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
--- update_at ON UPDATEで新しく取得した現在の日時を返す
-updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-FOREIGN KEY(child_id) REFERENCES Child_users(child_id) ON DELETE CASCADE,
-FOREIGN KEY(channel_id) REFERENCES Channel_tables(channel_id) ON DELETE CASCADE,
+CREATE TABLE messages (
+  message_id INT AUTO_INCREMENT PRIMARY KEY,
+  child_id INT NOT NULL,
+  message_content text NOT NULL,
+  send_date TIMESTAMP,
+  channel_id INT NOT NULL,
+  create_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY(child_id) REFERENCES children(child_id) ON DELETE CASCADE,
+  FOREIGN KEY(channel_id) REFERENCES channels(channel_id) ON DELETE CASCADE
 );
-
-
-
-
-
-
-


### PR DESCRIPTION
init.sqlの要素をすべて小文字に修正

一般的にSQL指示文は大文字で書いて他の要素は小文字で書くそうです